### PR TITLE
ci: GitHub Actions for lint, test, release-plz, and binary artifacts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      patch-and-minor:
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -18,7 +18,7 @@ jobs:
     name: cargo-audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,24 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: cargo-audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux BLE deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+      - run: cargo clippy --workspace --tests -- -D warnings
+      - run: cargo test --workspace
+      - run: cargo build --workspace

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,7 +23,7 @@ jobs:
             target: aarch64-apple-darwin
             archive_suffix: macos-aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -53,7 +53,7 @@ jobs:
           echo "sha256=dist/${name}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           files: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,62 @@
+name: Release binaries
+
+on:
+  push:
+    tags:
+      - 'nuimo-mqtt-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive_suffix: linux-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive_suffix: macos-aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install Linux BLE deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
+      - name: Build release binary
+        run: cargo build --release --package nuimo-mqtt --target ${{ matrix.target }}
+
+      - name: Package
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          name="nuimo-mqtt-${tag#nuimo-mqtt-v}-${{ matrix.archive_suffix }}"
+          mkdir -p "dist/${name}"
+          cp "target/${{ matrix.target }}/release/nuimo-mqtt" "dist/${name}/"
+          cp LICENSE-MIT LICENSE-APACHE README.md "dist/${name}/"
+          tar -czf "dist/${name}.tar.gz" -C dist "${name}"
+          (cd dist && shasum -a 256 "${name}.tar.gz" > "${name}.tar.gz.sha256")
+          echo "archive=dist/${name}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "sha256=dist/${name}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            ${{ steps.package.outputs.archive }}
+            ${{ steps.package.outputs.sha256 }}
+          fail_on_unmatched_files: true

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -15,7 +15,7 @@ jobs:
     concurrency:
       group: release-plz-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable
@@ -38,7 +38,7 @@ jobs:
       group: release-plz-pr
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,55 @@
+name: Release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux BLE deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-pr
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux BLE deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Run release-plz
+        uses: MarcoIeni/release-plz-action@v0
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,8 @@ dependencies = [
 [[package]]
 name = "weave-contracts"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a71ab6544a3fa46bce83d9b2b9972caf11b1688249f47d03294cb42ead1d9d06"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/nuimo-mqtt/Cargo.toml
+++ b/crates/nuimo-mqtt/Cargo.toml
@@ -12,6 +12,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-# Pulls the Glyph type + related contract so nuimo-mqtt can consume
-# retained `system/glyphs/{name}` publishes from weave-server.
-weave-contracts = { path = "../../../edge-agent/crates/weave-contracts" }
+weave-contracts = "0.1"

--- a/crates/nuimo-mqtt/src/main.rs
+++ b/crates/nuimo-mqtt/src/main.rs
@@ -82,8 +82,7 @@ async fn main() -> anyhow::Result<()> {
             }
             // Battery and RSSI would be read from device if connected
             // For now, publish placeholder
-            let _ =
-                mqtt::publish_rssi(&heartbeat_client, &heartbeat_device_id, -50).await;
+            let _ = mqtt::publish_rssi(&heartbeat_client, &heartbeat_device_id, -50).await;
         }
     });
 

--- a/crates/nuimo-mqtt/src/mqtt.rs
+++ b/crates/nuimo-mqtt/src/mqtt.rs
@@ -97,7 +97,12 @@ pub async fn publish_input(
 ) -> anyhow::Result<()> {
     let topic = format!("device/nuimo/{}/input/{}", device_id, primitive_name);
     client
-        .publish(&topic, QoS::AtMostOnce, false, serde_json::to_string(payload)?)
+        .publish(
+            &topic,
+            QoS::AtMostOnce,
+            false,
+            serde_json::to_string(payload)?,
+        )
         .await?;
     Ok(())
 }
@@ -116,11 +121,7 @@ pub async fn publish_battery(
 }
 
 /// Publish RSSI as device state.
-pub async fn publish_rssi(
-    client: &AsyncClient,
-    device_id: &str,
-    rssi: i16,
-) -> anyhow::Result<()> {
+pub async fn publish_rssi(client: &AsyncClient, device_id: &str, rssi: i16) -> anyhow::Result<()> {
     let topic = format!("device/nuimo/{}/state/rssi", device_id);
     client
         .publish(&topic, QoS::AtLeastOnce, false, rssi.to_string())
@@ -129,10 +130,7 @@ pub async fn publish_rssi(
 }
 
 /// Publish device connected event.
-pub async fn publish_connected(
-    client: &AsyncClient,
-    device_id: &str,
-) -> anyhow::Result<()> {
+pub async fn publish_connected(client: &AsyncClient, device_id: &str) -> anyhow::Result<()> {
     let topic = format!("device/nuimo/{}/state/connected", device_id);
     client
         .publish(&topic, QoS::AtLeastOnce, true, "true")

--- a/crates/nuimo-mqtt/src/registry.rs
+++ b/crates/nuimo-mqtt/src/registry.rs
@@ -69,7 +69,10 @@ mod tests {
     #[test]
     fn topic_to_name_matches_prefix() {
         assert_eq!(topic_to_name("system/glyphs/play"), Some("play"));
-        assert_eq!(topic_to_name("system/glyphs/volume_bar"), Some("volume_bar"));
+        assert_eq!(
+            topic_to_name("system/glyphs/volume_bar"),
+            Some("volume_bar")
+        );
         assert_eq!(topic_to_name("device/nuimo/x/feedback/y"), None);
     }
 }

--- a/crates/nuimo/examples/connect_test.rs
+++ b/crates/nuimo/examples/connect_test.rs
@@ -91,17 +91,24 @@ fn glyph_volume(pct: u8) -> Glyph {
         } else {
             s.push_str("         ");
         }
-        if row < 8 { s.push('\n'); }
+        if row < 8 {
+            s.push('\n');
+        }
     }
     Glyph::from_str(&s)
 }
 
 async fn show(device: &NuimoDevice, glyph: &Glyph, timeout_ms: u32) {
-    let _ = device.display_glyph(glyph, &DisplayOptions {
-        brightness: 1.0,
-        timeout_ms,
-        transition: DisplayTransition::Immediate,
-    }).await;
+    let _ = device
+        .display_glyph(
+            glyph,
+            &DisplayOptions {
+                brightness: 1.0,
+                timeout_ms,
+                transition: DisplayTransition::Immediate,
+            },
+        )
+        .await;
 }
 
 async fn handle_device(device: Arc<NuimoDevice>) {
@@ -123,54 +130,52 @@ async fn handle_device(device: Arc<NuimoDevice>) {
 
     loop {
         match events.recv().await {
-            Ok(event) => {
-                match &event {
-                    NuimoEvent::ButtonDown => {
-                        println!("[{}] Button DOWN", id);
-                        show(&device, &glyph_play(), 1500).await;
-                    }
-                    NuimoEvent::ButtonUp => {
-                        println!("[{}] Button UP", id);
-                        show(&device, &glyph_pause(), 1500).await;
-                    }
-                    NuimoEvent::Rotate { delta, .. } => {
-                        volume_pct = (volume_pct + delta * 100.0).clamp(0.0, 100.0);
-                        let pct = volume_pct as u8;
-                        println!("[{}] Rotate: delta={:.3} volume={}%", id, delta, pct);
-                        show(&device, &glyph_volume(pct), 1000).await;
-                    }
-                    NuimoEvent::SwipeRight => {
-                        println!("[{}] Swipe RIGHT", id);
-                        show(&device, &glyph_right(), 1000).await;
-                    }
-                    NuimoEvent::SwipeLeft => {
-                        println!("[{}] Swipe LEFT", id);
-                        show(&device, &glyph_left(), 1000).await;
-                    }
-                    NuimoEvent::SwipeUp => println!("[{}] Swipe UP", id),
-                    NuimoEvent::SwipeDown => println!("[{}] Swipe DOWN", id),
-                    NuimoEvent::TouchTop => println!("[{}] Touch TOP", id),
-                    NuimoEvent::TouchBottom => println!("[{}] Touch BOTTOM", id),
-                    NuimoEvent::TouchLeft => println!("[{}] Touch LEFT", id),
-                    NuimoEvent::TouchRight => println!("[{}] Touch RIGHT", id),
-                    NuimoEvent::LongTouchLeft => println!("[{}] Long Touch LEFT", id),
-                    NuimoEvent::LongTouchRight => println!("[{}] Long Touch RIGHT", id),
-                    NuimoEvent::LongTouchBottom => println!("[{}] Long Touch BOTTOM", id),
-                    NuimoEvent::LongTouchTop => println!("[{}] Long Touch TOP", id),
-                    NuimoEvent::Hover { proximity } => {
-                        println!("[{}] Hover: proximity={:.2}", id, proximity);
-                    }
-                    NuimoEvent::FlyLeft => println!("[{}] Fly LEFT", id),
-                    NuimoEvent::FlyRight => println!("[{}] Fly RIGHT", id),
-                    NuimoEvent::BatteryLevel(level) => println!("[{}] Battery: {}%", id, level),
-                    NuimoEvent::Rssi(rssi) => println!("[{}] RSSI: {} dBm", id, rssi),
-                    NuimoEvent::Connected => println!("[{}] Connected", id),
-                    NuimoEvent::Disconnected => {
-                        println!("[{}] Disconnected", id);
-                        return;
-                    }
+            Ok(event) => match &event {
+                NuimoEvent::ButtonDown => {
+                    println!("[{}] Button DOWN", id);
+                    show(&device, &glyph_play(), 1500).await;
                 }
-            }
+                NuimoEvent::ButtonUp => {
+                    println!("[{}] Button UP", id);
+                    show(&device, &glyph_pause(), 1500).await;
+                }
+                NuimoEvent::Rotate { delta, .. } => {
+                    volume_pct = (volume_pct + delta * 100.0).clamp(0.0, 100.0);
+                    let pct = volume_pct as u8;
+                    println!("[{}] Rotate: delta={:.3} volume={}%", id, delta, pct);
+                    show(&device, &glyph_volume(pct), 1000).await;
+                }
+                NuimoEvent::SwipeRight => {
+                    println!("[{}] Swipe RIGHT", id);
+                    show(&device, &glyph_right(), 1000).await;
+                }
+                NuimoEvent::SwipeLeft => {
+                    println!("[{}] Swipe LEFT", id);
+                    show(&device, &glyph_left(), 1000).await;
+                }
+                NuimoEvent::SwipeUp => println!("[{}] Swipe UP", id),
+                NuimoEvent::SwipeDown => println!("[{}] Swipe DOWN", id),
+                NuimoEvent::TouchTop => println!("[{}] Touch TOP", id),
+                NuimoEvent::TouchBottom => println!("[{}] Touch BOTTOM", id),
+                NuimoEvent::TouchLeft => println!("[{}] Touch LEFT", id),
+                NuimoEvent::TouchRight => println!("[{}] Touch RIGHT", id),
+                NuimoEvent::LongTouchLeft => println!("[{}] Long Touch LEFT", id),
+                NuimoEvent::LongTouchRight => println!("[{}] Long Touch RIGHT", id),
+                NuimoEvent::LongTouchBottom => println!("[{}] Long Touch BOTTOM", id),
+                NuimoEvent::LongTouchTop => println!("[{}] Long Touch TOP", id),
+                NuimoEvent::Hover { proximity } => {
+                    println!("[{}] Hover: proximity={:.2}", id, proximity);
+                }
+                NuimoEvent::FlyLeft => println!("[{}] Fly LEFT", id),
+                NuimoEvent::FlyRight => println!("[{}] Fly RIGHT", id),
+                NuimoEvent::BatteryLevel(level) => println!("[{}] Battery: {}%", id, level),
+                NuimoEvent::Rssi(rssi) => println!("[{}] RSSI: {} dBm", id, rssi),
+                NuimoEvent::Connected => println!("[{}] Connected", id),
+                NuimoEvent::Disconnected => {
+                    println!("[{}] Disconnected", id);
+                    return;
+                }
+            },
             Err(_) => return,
         }
     }

--- a/crates/nuimo/src/backend/linux.rs
+++ b/crates/nuimo/src/backend/linux.rs
@@ -208,7 +208,10 @@ impl NuimoPeripheral {
                 .map_err(|e| NuimoError::Ble(e.to_string()))?;
 
             for char in chars {
-                let uuid = char.uuid().await.map_err(|e| NuimoError::Ble(e.to_string()))?;
+                let uuid = char
+                    .uuid()
+                    .await
+                    .map_err(|e| NuimoError::Ble(e.to_string()))?;
                 tracing::debug!("  Characteristic: {}", uuid);
                 match uuid {
                     u if u == gatt::LED_MATRIX => led_char = Some(char),
@@ -276,7 +279,10 @@ impl NuimoPeripheral {
                 if data.len() >= 2 {
                     let raw = i16::from_le_bytes([data[0], data[1]]);
                     let delta = raw as f64 / gatt::ROTATION_POINTS_PER_CYCLE;
-                    Some(NuimoEvent::Rotate { delta, rotation: 0.0 })
+                    Some(NuimoEvent::Rotate {
+                        delta,
+                        rotation: 0.0,
+                    })
                 } else {
                     None
                 }
@@ -340,7 +346,11 @@ where
         tracing::info!("Subscribing to notifications (IO) for {}", uuid);
         match char.notify_io().await {
             Ok(reader) => {
-                tracing::info!("Notification IO established for {} (MTU={})", uuid, reader.mtu());
+                tracing::info!(
+                    "Notification IO established for {} (MTU={})",
+                    uuid,
+                    reader.mtu()
+                );
                 loop {
                     match reader.recv().await {
                         Ok(data) => {

--- a/crates/nuimo/src/backend/macos.rs
+++ b/crates/nuimo/src/backend/macos.rs
@@ -69,9 +69,7 @@ pub async fn discover(
         }
 
         while let Some(event) = events.next().await {
-            if let CentralEvent::DeviceDiscovered(id)
-            | CentralEvent::DeviceUpdated(id) = event
-            {
+            if let CentralEvent::DeviceDiscovered(id) | CentralEvent::DeviceUpdated(id) = event {
                 if let Ok(p) = central.peripheral(&id).await {
                     report_if_nuimo(&central, &p, &adapter_name, &tx).await;
                 }
@@ -189,9 +187,15 @@ impl NuimoPeripheral {
         }
 
         // Subscribe to every notify characteristic.
-        for ch in [&battery_char, &button_char, &rotation_char, &touch_char, &fly_char]
-            .iter()
-            .filter_map(|c| c.as_ref())
+        for ch in [
+            &battery_char,
+            &button_char,
+            &rotation_char,
+            &touch_char,
+            &fly_char,
+        ]
+        .iter()
+        .filter_map(|c| c.as_ref())
         {
             if let Err(e) = peripheral.subscribe(ch).await {
                 tracing::warn!(uuid = %ch.uuid, error = %e, "subscribe failed");
@@ -227,7 +231,10 @@ impl NuimoPeripheral {
                 } else if n.uuid == rotation_uuid && data.len() >= 2 {
                     let raw = i16::from_le_bytes([data[0], data[1]]);
                     let delta = raw as f64 / gatt::ROTATION_POINTS_PER_CYCLE;
-                    Some(NuimoEvent::Rotate { delta, rotation: 0.0 })
+                    Some(NuimoEvent::Rotate {
+                        delta,
+                        rotation: 0.0,
+                    })
                 } else if n.uuid == touch_uuid && !data.is_empty() {
                     parse_touch_or_swipe(data[0])
                 } else if n.uuid == fly_uuid {
@@ -291,7 +298,10 @@ impl NuimoPeripheral {
     }
 }
 
-fn find_char(chars: &std::collections::BTreeSet<Characteristic>, uuid: Uuid) -> Option<Characteristic> {
+fn find_char(
+    chars: &std::collections::BTreeSet<Characteristic>,
+    uuid: Uuid,
+) -> Option<Characteristic> {
     chars.iter().find(|c| c.uuid == uuid).cloned()
 }
 

--- a/crates/nuimo/src/device.rs
+++ b/crates/nuimo/src/device.rs
@@ -94,13 +94,20 @@ impl NuimoDevice {
                     NuimoEvent::Rotate { delta, .. } => {
                         let mode = *rotation_mode.lock().await;
                         match mode {
-                            RotationMode::Continuous => NuimoEvent::Rotate { delta, rotation: 0.0 },
+                            RotationMode::Continuous => NuimoEvent::Rotate {
+                                delta,
+                                rotation: 0.0,
+                            },
                             RotationMode::Clamped => {
                                 let mut state = rotation_state.lock().await;
                                 let range = state.max - state.min;
                                 let cycle_delta = delta * range / state.cycles;
-                                state.value = (state.value + cycle_delta).clamp(state.min, state.max);
-                                NuimoEvent::Rotate { delta, rotation: state.value }
+                                state.value =
+                                    (state.value + cycle_delta).clamp(state.min, state.max);
+                                NuimoEvent::Rotate {
+                                    delta,
+                                    rotation: state.value,
+                                }
                             }
                         }
                     }

--- a/crates/nuimo/src/glyph.rs
+++ b/crates/nuimo/src/glyph.rs
@@ -40,6 +40,7 @@ impl Glyph {
     ///
     /// Each line represents a row (up to 9 lines). Use `*` for on, anything else for off.
     /// Lines are separated by newlines.
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         let mut rows = [0u16; LED_ROWS];
         for (row_idx, line) in s.lines().enumerate() {

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,11 @@
+[workspace]
+changelog_update = true
+pr_branch_prefix = "release-plz/"
+
+[[package]]
+name = "nuimo"
+publish = true
+
+[[package]]
+name = "nuimo-mqtt"
+publish = false


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml`: rustfmt + clippy (`-D warnings`) + test + build on Ubuntu and macOS for every PR and push to main. Installs `libdbus-1-dev` on Linux for `bluer`.
- Adopt **release-plz** (`release-plz.yml` + `release-plz.toml`): `nuimo` SDK publishes to crates.io; `nuimo-mqtt` is `publish = false` so release-plz version-bumps and tags it without touching crates.io.
- Add `release-binaries.yml`: on `nuimo-mqtt-v*` tags build Linux x86_64 and macOS aarch64, package to tar.gz with SHA256, attach to the Release release-plz created.
- Add `audit.yml` (weekly + on Cargo changes) and `dependabot.yml` (weekly cargo + github-actions).
- Switch `nuimo-mqtt` from the sibling-repo path dependency on `weave-contracts` to `"0.1"` (published from edge-agent PR shin1ohno/edge-agent#3 — required for CI to resolve dependencies).
- Pre-commit housekeeping: `cargo fmt --all` pass and `#[allow(clippy::should_implement_trait)]` on `Glyph::from_str` (renaming or implementing `FromStr` would be a breaking 0.1.0 API change).

## Required repo configuration
- Add `CARGO_REGISTRY_TOKEN` secret scoped to the `nuimo` crate.
- Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests" (release-plz PR flow).

## Test plan
- [ ] CI (Ubuntu + macOS) goes green on this PR.
- [ ] After merge to main, release-plz opens a Release PR for `nuimo-v0.1.0` / `nuimo-mqtt-v0.1.0`.
- [ ] Merging the Release PR triggers `cargo publish` of `nuimo` on crates.io and pushes both tags.
- [ ] `nuimo-mqtt-v0.1.0` tag triggers `release-binaries.yml`; Linux and macOS tarballs appear on the GitHub Release with matching `.sha256` files.
- [ ] Weekly `audit.yml` schedule visible in the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)