### PR TITLE
nuimo: 0.1.1 — macOS shared CBCentralManager fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "nuimo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "bluer",

--- a/crates/nuimo/Cargo.toml
+++ b/crates/nuimo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuimo"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Rust SDK for Senic Nuimo Control BLE smart knob — discovery, rotation, touch, swipe, and LED matrix"

--- a/crates/nuimo/src/backend/macos.rs
+++ b/crates/nuimo/src/backend/macos.rs
@@ -15,12 +15,40 @@ use btleplug::api::{
 };
 use btleplug::platform::{Adapter, Manager, Peripheral, PeripheralId};
 use futures::StreamExt;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, OnceCell};
 use uuid::Uuid;
 
 use crate::error::NuimoError;
 use crate::event::{parse_fly, parse_touch_or_swipe, NuimoEvent};
 use crate::gatt;
+
+// On macOS, CoreBluetooth keys peripherals to the CBCentralManager that
+// discovered them: a fresh `Manager::new()` has an empty peripheral cache,
+// so retrieving the discovered peripheral by UUID fails with "Device not
+// found". Sharing a single process-wide Adapter between `discover()` and
+// `NuimoPeripheral::connect()` lets connect use the same CoreBluetooth
+// cache the scan populated.
+static SHARED_ADAPTER: OnceCell<Arc<Adapter>> = OnceCell::const_new();
+
+async fn shared_adapter() -> Result<Arc<Adapter>, NuimoError> {
+    SHARED_ADAPTER
+        .get_or_try_init(|| async {
+            let manager = Manager::new()
+                .await
+                .map_err(|e| NuimoError::Ble(e.to_string()))?;
+            let adapters = manager
+                .adapters()
+                .await
+                .map_err(|e| NuimoError::Ble(e.to_string()))?;
+            let adapter = adapters
+                .into_iter()
+                .next()
+                .ok_or_else(|| NuimoError::Ble("no Bluetooth adapter found".into()))?;
+            Ok(Arc::new(adapter))
+        })
+        .await
+        .cloned()
+}
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredNuimo {
@@ -31,17 +59,7 @@ pub struct DiscoveredNuimo {
 
 pub async fn discover(
 ) -> Result<(mpsc::Receiver<DiscoveredNuimo>, tokio::task::JoinHandle<()>), NuimoError> {
-    let manager = Manager::new()
-        .await
-        .map_err(|e| NuimoError::Ble(e.to_string()))?;
-    let adapters = manager
-        .adapters()
-        .await
-        .map_err(|e| NuimoError::Ble(e.to_string()))?;
-    let central = adapters
-        .into_iter()
-        .next()
-        .ok_or_else(|| NuimoError::Ble("no Bluetooth adapter found".into()))?;
+    let central = shared_adapter().await?;
     let adapter_name = "default".to_string();
 
     central
@@ -126,19 +144,7 @@ impl NuimoPeripheral {
         _adapter_hint: Option<&str>,
         event_tx: mpsc::Sender<NuimoEvent>,
     ) -> Result<Self, NuimoError> {
-        let manager = Manager::new()
-            .await
-            .map_err(|e| NuimoError::Ble(e.to_string()))?;
-        let adapters = manager
-            .adapters()
-            .await
-            .map_err(|e| NuimoError::Ble(e.to_string()))?;
-        let central = Arc::new(
-            adapters
-                .into_iter()
-                .next()
-                .ok_or_else(|| NuimoError::Ble("no Bluetooth adapter found".into()))?,
-        );
+        let central = shared_adapter().await?;
 
         let peripheral_id = parse_peripheral_id(id)?;
         let peripheral = central


### PR DESCRIPTION
## Summary
- Fix: `NuimoDevice::connect()` on macOS previously instantiated a fresh `CBCentralManager`, whose empty peripheral cache caused `central.peripheral(id)` to return `Device not found` for the just-discovered Nuimo. Now `discover()` and `connect()` share a process-wide `OnceCell<Arc<Adapter>>`, so connect reuses the scan's CoreBluetooth cache.
- Bumps `nuimo` to `0.1.1`.
- Also brings in pending commits: release-plz CI automation, nuimo-mqtt → weave-contracts@crates.io, workspace rustfmt + FromStr lint tweak.

## Repro of the bug the fix targets
Terminal `cargo run -p nuimo --example connect_test` — then, against an edge-agent built on the previous version of this SDK:
```
INFO nuimo::backend::macos: Discovered Nuimo: Nuimo (ea231cb2-...)
INFO edge_agent: nuimo found ...
Error: BLE error: Device not found
```
After this PR: discovery → connect → event stream all succeed on macOS Sonoma/Sequoia.

Linux backend (bluer) shares peripherals system-wide, so only the macOS backend was affected.

## Test plan
- [ ] CI green (lint, test, audit)
- [ ] Local verification on macOS: build edge-agent against this nuimo, run against Nuimo hardware, confirm Nuimo events flow through to the Roon adapter (volume rotate, play/pause press, etc.)
- [ ] release-plz auto-publishes `nuimo@0.1.1` to crates.io after merge