### PR TITLE
ci(release-plz): pin action to v0.5.128

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0
+        uses: MarcoIeni/release-plz-action@v0.5.128
         with:
           command: release
         env:
@@ -47,7 +47,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev pkg-config
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0
+        uses: MarcoIeni/release-plz-action@v0.5.128
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary
- `MarcoIeni/release-plz-action@v0` no longer resolves (no `v0` tag exists upstream — latest is `v0.5.128`). CI failed on the 0.1.1 merge with `Unable to resolve action marcoieni/release-plz-action@v0, unable to find version v0`.
- Pin to `@v0.5.128` on both release-plz jobs.

## Test plan
- [ ] After merge, Release-plz workflow runs green on `main`
- [ ] Release-plz publishes `nuimo@0.1.1` to crates.io (bump was already merged in PR #4)