### PR TITLE
nuimo-mqtt: pin nuimo path dep with version fallback

### DIFF
--- a/crates/nuimo-mqtt/Cargo.toml
+++ b/crates/nuimo-mqtt/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-nuimo = { path = "../nuimo" }
+nuimo = { path = "../nuimo", version = "0.1" }
 rumqttc = "0.24"
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
`cargo package -p nuimo-mqtt` fails with:
```
dependency `nuimo` does not specify a version
```
This bubbles up into release-plz's workspace diff, making the release-plz workflow red on every main push (even though `nuimo-mqtt` has `publish = false` in release-plz.toml — release-plz still packages the whole workspace internally).

Fix: specify `version = "0.1"` alongside the path dep. Local workspace builds keep using `../nuimo`; packaging / registry consumption records the version requirement.

## Verify
- [x] `cargo package -p nuimo-mqtt --no-verify` green locally
- [ ] After merge, release-plz workflow green on main