### PR TITLE
ci(release-plz): serialize PR job after release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -33,6 +33,7 @@ jobs:
 
   release-plz-pr:
     name: Release-plz PR
+    needs: release-plz-release
     runs-on: ubuntu-latest
     concurrency:
       group: release-plz-pr


### PR DESCRIPTION
## Summary
Add `needs: release-plz-release` to the release-plz PR job so it runs strictly after the release job. Without this, on a main push that bumps a version, the two jobs race: `release-plz-pr` queries crates.io for the latest version **before** `release-plz-release` finishes publishing, gets the old baseline, and may hit historical commit issues depending on repo history. Serializing guarantees the PR job always sees the freshly-published version as baseline.

## Blast radius
- 1 line added (`needs: release-plz-release`).
- PR job now waits for release job — negligible extra wall-clock time.