### PR TITLE
docs: document operational notes (latency floor + SDK semver)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ while let Ok(event) = events.recv().await {
 }
 ```
 
+## Operational Notes
+
+### Latency floor
+
+- BLE connection interval on Nuimo peripherals is typically 7.5–30 ms. That's the hard lower bound on how often `NuimoEvent::Rotate { delta }` can physically arrive — the SDK can't deliver ticks faster than the radio schedules them.
+- LED matrix writes are one GATT write per frame. Back-to-back writes are rate-limited by the same connection interval; callers that stream high-frequency updates (e.g. volume-bar animation tied to rotate deltas) should coalesce on the consumer side.
+- Disconnects are frequent and unannounced (low battery, out-of-range, host BLE stack hiccup). `NuimoDevice` does not retry automatically today — the consumer owns the reconnect strategy. `@see` the Events channel draining to detect the end of a session.
+
+### Compatibility policy
+
+- `nuimo` is the public Rust SDK. Treat `NuimoEvent`, `NuimoDevice`, and the `discover()` channel signature as the API surface.
+- Today's semver rules:
+  - **MINOR** — struct field addition on event payloads (downstream match arms keep compiling if they use `..`).
+  - **MAJOR** — `NuimoEvent` enum variant addition (pattern matches without a `_ =>` arm break at compile time). Consumers that want forward-compat can add `_ => {}` today and we can relax this later with `#[non_exhaustive]`.
+  - **MAJOR** — method rename, trait bound change, or backend swap (bluer ↔ btleplug selection, OS gating).
+- `nuimo-mqtt` is a consumer of `nuimo`, not part of the SDK. It ships on a separate version line and its own CHANGELOG.
+
 ## License
 
 Licensed under either of [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE), at your option.


### PR DESCRIPTION
## Summary

Add an `## Operational Notes` section to README covering:

- **Latency floor**: BLE connection interval (7.5–30 ms) bounds `NuimoEvent::Rotate` delivery rate and LED matrix write rate.
- **Compatibility policy**: `NuimoEvent` enum variant addition is MAJOR today (pattern matches without `_ =>` break at compile time). `nuimo-mqtt` is a consumer and rolls forward on its own version line.

Part of a cross-repo pass after a `/roundtable:start` review on the weave ecosystem — half of the high-priority findings traced back to assumptions that were never written down.

Documentation only. No code change, no behavior change.

## Test plan

- [ ] Render README on GitHub preview; confirm the section appears before `## License`
- [ ] Wording stays consistent with the corresponding sections in the sibling PRs (`weave`, `edge-agent`, `roon-rs`)